### PR TITLE
Add sandbox to known environments

### DIFF
--- a/ruby/rails_rubocop.yml
+++ b/ruby/rails_rubocop.yml
@@ -37,3 +37,10 @@ AllCops:
 
 Rails:
   Enabled: true
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - sandbox
+    - test


### PR DESCRIPTION
Stop RuboCop from complaining about referring to the `sandbox`
environment.