### PR TITLE
Extern - Allow deeper nested

### DIFF
--- a/ruby/rubocop_rspec.yml
+++ b/ruby/rubocop_rspec.yml
@@ -39,3 +39,6 @@ RSpec/VerifiedDoubles:
 
 RSpec/ScatteredSetup:
   Enabled: true
+
+RSpec/NestedGroups:
+  Max: 5


### PR DESCRIPTION
Jag tycker att det är trevligt att kunna nesta lite längre. Tex:

```ruby
  describe "#import_runnable?" do
    subject { import.import_runnable? }

    let(:import) { create :business_grouped_invoice_import }

    context "when the import is closed" do
      before do
        import.update(closed: true)
      end

      it { is_expected.to be false }
    end

    context "when the import isn't closed" do
      before do
        import.update(closed: false)
      end

      context "with a invoice that has started exporting" do
        let!(:grouped_invoice) do
          create :business_grouped_invoice, export_state: "processing", import: import
        end

        it { is_expected.to be false }
      end

      context "with a invoice that has not started exporting" do
        let!(:grouped_invoice) do
          create :business_grouped_invoice, export_state: "new", import: import
        end

        it { is_expected.to be true }
      end
    end
  end
```