### PR TITLE
Disable Style/ModuleFunction

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -91,3 +91,13 @@ Style/TrailingCommaInArrayLiteral:
 #
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: 'comma'
+
+# === OVERRIDE ===
+#
+# - https://rubocop.readthedocs.io/en/latest/cops_style/#stylemodulefunction
+#
+# Why? `extend self` and `module_function` are not the same
+#      More info: https://github.com/rubocop-hq/ruby-style-guide/issues/556
+#
+Style/ModuleFunction:
+  Enabled: false


### PR DESCRIPTION
`extend self` and `module_function` are not the same
see https://github.com/rubocop-hq/ruby-style-guide/issues/556