### PR TITLE
Disable documentation cop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -84,6 +84,9 @@ Style/BlockDelimiters:
 Style/CollectionMethods:
   Enabled: true
 
+Style/Documentation:
+  Enabled: false
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
 


### PR DESCRIPTION
We either end up with a bunch of :nodoc: or repetitive comments that
doesn't add much