### PR TITLE
Extern disable obsolete cop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -25,7 +25,7 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 15
   Exclude:
-  - spec/**/*
+    - spec/**/*
 
 Metrics/AbcSize:
   Max: 20
@@ -120,6 +120,9 @@ Style/StringHashKeys:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
@@ -152,15 +155,14 @@ Lint/ReturnInVoidContext:
 Lint/Void:
   Enabled: false
 
-
 ################################################################################
 # Specs - be more lenient on length checks and block styles
 ################################################################################
 
 Metrics/BlockLength:
   Exclude:
-  - spec/**/*
+    - spec/**/*
 
 Style/ClassAndModuleChildren:
   Exclude:
-  - spec/**/*
+    - spec/**/*


### PR DESCRIPTION
Denna cop är obsolete i rubocop men codeclimate envisas med att använda
den. Jag hoppas vi slipper det felet genom att explicit stänga av den.

![image](https://user-images.githubusercontent.com/22270/65959960-9f725700-e453-11e9-82f0-f80751c1e43a.png)
