### PR TITLE
Disable naming rule for exception variable in rescue clause

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -121,7 +121,7 @@ Style/ModuleFunction:
 
 # === OVERRIDE ===
 #
-# - https://rubocop.readthedocs.io/en/latest/cops_naming/
+# - https://rubocop.readthedocs.io/en/latest/cops_naming/#namingrescuedexceptionsvariablename
 #
 # Why? Enforcing specific name rules on local variables leads to unnecessary noise. We should spend time on the things that matter
 #

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -118,3 +118,13 @@ Style/TrailingCommaInHashLiteral:
 #
 Style/ModuleFunction:
   Enabled: false
+
+# === OVERRIDE ===
+#
+# - https://rubocop.readthedocs.io/en/latest/cops_naming/
+#
+# Why? Enforcing specific name rules on local variables leads to unnecessary noise. We should spend time on the things that matter
+#
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+  


### PR DESCRIPTION
We should focus on what's important and not on nitty-gritty details.