### PR TITLE
Disable ordered gems cop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -138,6 +138,9 @@ Style/TrailingUnderscoreVariable:
 Style/Lambda:
   EnforcedStyle: literal
 
+Bundler/OrderedGems:
+  Enabled: false
+
 ################################################################################
 # performance
 ################################################################################


### PR DESCRIPTION
I don't think this makes sense, i think we should be able to order gems
in a logical way. Alphabetically is most often not logical, if i need to
find a gem in the file i __search for it__