### PR TITLE
[FV] Allow ambiguousblockassociations in specs

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -155,6 +155,10 @@ Lint/ReturnInVoidContext:
 Lint/Void:
   Enabled: false
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 ################################################################################
 # Specs - be more lenient on length checks and block styles
 ################################################################################


### PR DESCRIPTION
Annars klagar den på

```ruby
expect {
  subject
}.not_to change { WholesaleStockStatus.count }
```