### PR TITLE
Disable Lint/UselessMethodDefinition

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -75,6 +75,13 @@ Lint/MixedRegexpCaptureTypes:
 Lint/StructNewOverride:
   Enabled: true
 
+# === DISABLE ===
+#
+# Why? Be explicit about controller actions.
+#
+Lint/UselessMethodDefinition:
+  Enabled: false
+
 ################################################################################
 # Metrics
 #


### PR DESCRIPTION
Allow us to be explicit about what controller actions is used.
![image](https://user-images.githubusercontent.com/1053201/94368402-1d5b5380-00e4-11eb-9fd4-fb1aa9a05acb.png)
