### PR TITLE
Cop has migrated to RSpec/Dialect

### DIFF
--- a/ruby/rspec_rubocop.yml
+++ b/ruby/rspec_rubocop.yml
@@ -139,12 +139,12 @@ RSpec/NestedGroups:
 
 # === ENABLE ===
 #
-# - https://docs.rubocop.org/rubocop-rspec/cops_rspec/capybara.html#rspeccapybarafeaturemethods
+# - https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecdialect
 #
 # Why? We like it this way.
 #
-RSpec/Capybara/FeatureMethods:
-  EnabledMethods:
+RSpec/Dialect:
+  Enabled:
     - scenario
     - xscenario
     - feature


### PR DESCRIPTION
Apparently the RSpec/Capybara/FeatureMethods cop has been removed since this cop has migrated to RSpec/Dialect.

![Screenshot 2024-08-06 at 15 17 24](https://github.com/user-attachments/assets/6a6b3dfe-1879-45d5-92a0-d7148702621a)
